### PR TITLE
feat: add HCS-2 and HCS-20 documentation and update sidebar

### DIFF
--- a/docs/libraries/standards-sdk/hcs-2.md
+++ b/docs/libraries/standards-sdk/hcs-2.md
@@ -1,0 +1,253 @@
+---
+sidebar_position: 2
+---
+
+# HCS-2: Decentralized Topic Registry
+
+The HCS-2 module provides a decentralized registry for Hedera Consensus Service (HCS) topics. It allows for the discovery and management of topics in a standardized way, supporting both indexed and non-indexed registries.
+
+## What HCS-2 Does
+
+- **Creates Registries** - Establishes new HCS topics to act as registries.
+- **Manages Entries** - Supports registering, updating, deleting, and migrating topic entries.
+- **Standardized Memos** - Uses a specific memo format for identifying HCS-2 registries.
+- **Flexible Queries** - Allows for fetching and parsing registry entries.
+
+## Getting Started
+
+### Installation
+
+```bash
+npm install @hashgraphonline/standards-sdk
+```
+
+### Basic Setup (Node.js)
+
+For server-side applications, use `HCS2Client`.
+
+```typescript
+import { HCS2Client } from '@hashgraphonline/standards-sdk/dist/hcs-2';
+import { HCS2RegistryType } from '@hashgraphonline/standards-sdk/dist/hcs-2/types';
+
+// Initialize the HCS-2 client
+const client = new HCS2Client({
+  network: 'testnet',
+  operatorId: 'your-operator-id',
+  operatorKey: 'your-operator-private-key',
+  logLevel: 'info',
+});
+```
+
+### Basic Setup (Browser)
+
+For client-side applications, use `BrowserHCS2Client` with a wallet connection.
+
+```typescript
+import { BrowserHCS2Client } from '@hashgraphonline/standards-sdk/dist/hcs-2';
+import { HCS2RegistryType } from '@hashgraphonline/standards-sdk/dist/hcs-2/types';
+import { HashinalsWalletConnectSDK } from '@hashgraphonline/hashinal-wc';
+
+// Initialize Hashinals WalletConnect
+const hwc = new HashinalsWalletConnectSDK();
+await hwc.init(/** wallet connect options */);
+await hwc.connect(/** connection options */);
+
+// Initialize the HCS-2 browser client
+const browserClient = new BrowserHCS2Client({
+  network: 'testnet',
+  hwc: hwc,
+  logLevel: 'info',
+});
+```
+
+## Creating a Registry
+
+Create a new topic that will serve as a registry.
+
+```typescript
+// Create an indexed registry
+const response = await client.createRegistry({
+  registryType: HCS2RegistryType.INDEXED,
+  ttl: 3600, // Time-to-live in seconds
+  memo: 'My Indexed Registry',
+  adminKey: true, // Use operator key as admin key
+});
+
+if (response.success) {
+  console.log(`Registry created with topic ID: ${response.topicId}`);
+} else {
+  console.error(`Error: ${response.error}`);
+}
+```
+
+## Managing Registry Entries
+
+### Registering an Entry
+
+Add a new topic to your registry.
+
+```typescript
+const registryTopicId = '0.0.12345'; // Your registry topic ID
+
+const registerResponse = await client.registerEntry(registryTopicId, {
+  targetTopicId: '0.0.67890', // The topic to register
+  metadata: 'https://example.com/metadata.json',
+  memo: 'Initial registration',
+});
+
+if (registerResponse.success) {
+  console.log(`Entry registered. Sequence number: ${registerResponse.sequenceNumber}`);
+} else {
+  console.error(`Error: ${registerResponse.error}`);
+}
+```
+
+### Updating an Entry
+
+Update an existing entry in an indexed registry. You need the unique ID (`uid`) of the message, which is typically the `sequence_number` of the registration message.
+
+```typescript
+const updateResponse = await client.updateEntry(registryTopicId, {
+  uid: '1', // The sequence number of the message to update
+  targetTopicId: '0.0.98765', // New target topic
+  metadata: 'https://example.com/new-metadata.json',
+  memo: 'Updated registration',
+});
+
+if (updateResponse.success) {
+  console.log(`Entry updated. New sequence number: ${updateResponse.sequenceNumber}`);
+} else {
+  console.error(`Error: ${updateResponse.error}`);
+}
+```
+
+### Deleting an Entry
+
+Delete an entry from an indexed registry using its `uid`.
+
+```typescript
+const deleteResponse = await client.deleteEntry(registryTopicId, {
+  uid: '1', // The sequence number of the message to delete
+  memo: 'Entry deleted',
+});
+
+if (deleteResponse.success) {
+  console.log(`Entry deleted. Sequence number: ${deleteResponse.sequenceNumber}`);
+} else {
+  console.error(`Error: ${deleteResponse.error}`);
+}
+```
+
+### Migrating a Registry
+
+Point an entire registry to a new topic. This is useful for versioning or upgrades.
+
+```typescript
+const migrateResponse = await client.migrateRegistry(registryTopicId, {
+  targetTopicId: '0.0.54321', // The new registry topic
+  memo: 'Migrating to new registry',
+});
+
+if (migrateResponse.success) {
+  console.log(`Registry migrated. Sequence number: ${migrateResponse.sequenceNumber}`);
+} else {
+  console.error(`Error: ${migrateResponse.error}`);
+}
+```
+
+## Querying a Registry
+
+Fetch all entries from a registry.
+
+```typescript
+const registryData = await client.getRegistry(registryTopicId, {
+  limit: 100,
+  order: 'asc',
+});
+
+console.log(`Registry Type: ${registryData.registryType}`);
+console.log(`TTL: ${registryData.ttl}`);
+
+for (const entry of registryData.entries) {
+  console.log(`- Sequence: ${entry.sequence}`);
+  console.log(`  Timestamp: ${entry.timestamp}`);
+  console.log(`  Payer: ${entry.payer}`);
+  console.log(`  Message:`, entry.message);
+}
+
+if (registryData.latestEntry) {
+    console.log(`Latest entry: `, registryData.latestEntry.message);
+}
+```
+
+## API Reference
+
+### HCS2Client / BrowserHCS2Client
+
+The API is consistent between the Node.js and Browser clients.
+
+#### `createRegistry(options: CreateRegistryOptions): Promise<TopicRegistrationResponse>`
+Creates a new HCS-2 registry topic.
+
+#### `registerEntry(registryTopicId: string, options: RegisterEntryOptions): Promise<RegistryOperationResponse>`
+Registers a new topic in the registry.
+
+#### `updateEntry(registryTopicId: string, options: UpdateEntryOptions): Promise<RegistryOperationResponse>`
+Updates an existing entry in an indexed registry.
+
+#### `deleteEntry(registryTopicId: string, options: DeleteEntryOptions): Promise<RegistryOperationResponse>`
+Deletes an entry from an indexed registry.
+
+#### `migrateRegistry(registryTopicId: string, options: MigrateTopicOptions): Promise<RegistryOperationResponse>`
+Submits a migration message to a registry topic.
+
+#### `getRegistry(topicId: string, options?: QueryRegistryOptions): Promise<TopicRegistry>`
+Retrieves and parses all entries from a registry topic.
+
+### Types
+
+```typescript
+enum HCS2RegistryType {
+  INDEXED = 0,
+  NON_INDEXED = 1
+}
+
+interface CreateRegistryOptions {
+  memo?: string;
+  ttl?: number;
+  adminKey?: boolean | string | PrivateKey;
+  submitKey?: boolean | string | PrivateKey;
+  registryType?: HCS2RegistryType;
+}
+
+interface RegisterEntryOptions {
+  targetTopicId: string;
+  metadata?: string;
+  memo?: string;
+}
+
+interface UpdateEntryOptions {
+  targetTopicId: string;
+  uid: string;
+  metadata?: string;
+  memo?: string;
+}
+
+interface DeleteEntryOptions {
+  uid: string;
+  memo?: string;
+}
+
+interface MigrateTopicOptions {
+  targetTopicId: string;
+  metadata?: string;
+  memo?: string;
+}
+
+interface QueryRegistryOptions {
+  limit?: number;
+  order?: 'asc' | 'desc';
+  skip?: number;
+}
+```
+

--- a/docs/libraries/standards-sdk/hcs-20.md
+++ b/docs/libraries/standards-sdk/hcs-20.md
@@ -1,0 +1,246 @@
+---
+sidebar_position: 6
+---
+
+# HCS-20: Auditable Points Standard
+
+The HCS-20 module provides a standard for creating and managing auditable points (like loyalty points or in-game currencies) on the Hedera Consensus Service. It includes clients for both server-side (Node.js) and client-side (browser) environments, along with an indexer for tracking the state of points.
+
+## What HCS-20 Does
+
+- **Defines a Standard** - A clear message schema for deploying, minting, transferring, and burning points.
+- **Provides SDK Clients** - `HCS20Client` for Node.js and `BrowserHCS20Client` for browsers to interact with the HCS-20 standard.
+- **Includes an Indexer** - `HCS20PointsIndexer` to process topic messages and maintain the state of points.
+- **Supports Public and Private Topics** - Deploy points on a public topic or on your own private, permissioned topic.
+
+## Getting Started
+
+### Installation
+
+```bash
+npm install @hashgraphonline/standards-sdk
+```
+
+### Basic Setup (Node.js)
+
+For server-side applications, use `HCS20Client`.
+
+```typescript
+import { HCS20Client } from '@hashgraphonline/standards-sdk/dist/hcs-20';
+
+// Initialize the HCS-20 client
+const client = new HCS20Client({
+  network: 'testnet',
+  operatorId: 'your-operator-id',
+  operatorKey: 'your-operator-private-key',
+  logLevel: 'info',
+});
+```
+
+### Basic Setup (Browser)
+
+For client-side applications, use `BrowserHCS20Client` with a wallet connection.
+
+```typescript
+import { BrowserHCS20Client } from '@hashgraphonline/standards-sdk/dist/hcs-20';
+import { HashinalsWalletConnectSDK } from '@hashgraphonline/hashinal-wc';
+
+// Initialize Hashinals WalletConnect
+const hwc = new HashinalsWalletConnectSDK();
+await hwc.init(/** wallet connect options */);
+await hwc.connect(/** connection options */);
+
+// Initialize the HCS-20 browser client
+const browserClient = new BrowserHCS20Client({
+  network: 'testnet',
+  hwc: hwc,
+  logLevel: 'info',
+});
+```
+
+## Deploying Points
+
+Create a new type of points on the network.
+
+```typescript
+const deployOptions = {
+  name: 'MyRewardPoints',
+  tick: 'MRP',
+  maxSupply: '1000000',
+  limitPerMint: '1000',
+  metadata: 'https://my-reward-points.com/meta',
+  usePrivateTopic: false, // Set to true to create a new private topic
+  progressCallback: (data) => {
+    console.log(`${data.stage}: ${data.percentage}%`);
+  }
+};
+
+const pointsInfo = await client.deployPoints(deployOptions);
+console.log('Points deployed:', pointsInfo);
+```
+
+## Point Operations
+
+### Minting Points
+
+Create new points and assign them to an account.
+
+```typescript
+const mintOptions = {
+  tick: 'MRP',
+  amount: '500',
+  to: '0.0.98765', // Recipient account ID
+  memo: 'Initial points for new user',
+  progressCallback: (data) => {
+    console.log(`${data.stage}: ${data.percentage}%`);
+  }
+};
+
+const mintTransaction = await client.mintPoints(mintOptions);
+console.log('Mint transaction:', mintTransaction);
+```
+
+### Transferring Points
+
+Move points from one account to another.
+
+```typescript
+const transferOptions = {
+  tick: 'MRP',
+  amount: '100',
+  from: '0.0.12345', // Sender account ID
+  to: '0.0.98765',   // Recipient account ID
+  progressCallback: (data) => {
+    console.log(`${data.stage}: ${data.percentage}%`);
+  }
+};
+
+const transferTransaction = await client.transferPoints(transferOptions);
+console.log('Transfer transaction:', transferTransaction);
+```
+
+### Burning Points
+
+Permanently remove points from circulation.
+
+```typescript
+const burnOptions = {
+  tick: 'MRP',
+  amount: '50',
+  from: '0.0.98765', // Account to burn from
+  progressCallback: (data) => {
+    console.log(`${data.stage}: ${data.percentage}%`);
+  }
+};
+
+const burnTransaction = await client.burnPoints(burnOptions);
+console.log('Burn transaction:', burnTransaction);
+```
+
+## Using the Points Indexer
+
+The `HCS20PointsIndexer` listens to HCS topics and builds a local state of all points, balances, and transactions.
+
+```typescript
+import { HCS20PointsIndexer } from '@hashgraphonline/standards-sdk/dist/hcs-20';
+
+const indexer = new HCS20PointsIndexer('testnet');
+
+// Start indexing in the background
+indexer.startIndexing({
+  // Optional: add private topics to watch
+  // privateTopics: ['0.0.112233']
+});
+
+// To fetch the state at any time:
+const currentState = indexer.getState();
+console.log('All deployed points:', currentState.deployedPoints);
+console.log('All balances:', currentState.balances);
+
+// Get info for a specific point
+const mrpInfo = indexer.getPointsInfo('MRP');
+console.log('MRP Info:', mrpInfo);
+
+// Get a specific balance
+const balance = indexer.getBalance('MRP', '0.0.98765');
+console.log('Balance for 0.0.98765:', balance);
+
+// Stop indexing
+// indexer.stopIndexing();
+```
+
+## API Reference
+
+### HCS20Client / BrowserHCS20Client
+
+#### `deployPoints(options: DeployPointsOptions): Promise<PointsInfo>`
+Deploys a new set of points.
+
+#### `mintPoints(options: MintPointsOptions): Promise<PointsTransaction>`
+Mints new points.
+
+#### `transferPoints(options: TransferPointsOptions): Promise<PointsTransaction>`
+Transfers points between accounts.
+
+#### `burnPoints(options: BurnPointsOptions): Promise<PointsTransaction>`
+Burns points.
+
+#### `registerTopic(options: RegisterTopicOptions): Promise<void>`
+Registers a topic in the HCS-20 registry.
+
+### HCS20PointsIndexer
+
+#### `startIndexing(options?)`
+Starts the indexing process.
+
+#### `stopIndexing()`
+Stops the indexing process.
+
+#### `getState(): PointsState`
+Returns a snapshot of the current points state.
+
+#### `getPointsInfo(tick: string): PointsInfo | undefined`
+Gets information about a specific point type.
+
+#### `getBalance(tick: string, accountId: string): string`
+Gets the balance of a specific point for an account.
+
+### Types
+
+```typescript
+interface PointsInfo {
+  name: string;
+  tick: string;
+  maxSupply: string;
+  limitPerMint?: string;
+  metadata?: string;
+  topicId: string;
+  deployerAccountId: string;
+  currentSupply: string;
+  deploymentTimestamp: string;
+  isPrivate: boolean;
+}
+
+interface PointsTransaction {
+  id: string;
+  operation: 'deploy' | 'mint' | 'transfer' | 'burn' | 'register';
+  tick: string;
+  amount?: string;
+  from?: string;
+  to?: string;
+  timestamp: string;
+  sequenceNumber: number;
+  topicId: string;
+  transactionId: string;
+  memo?: string;
+}
+
+interface PointsState {
+  deployedPoints: Map<string, PointsInfo>;
+  balances: Map<string, Map<string, PointsBalance>>;
+  transactions: PointsTransaction[];
+  lastProcessedSequence: number;
+  lastProcessedTimestamp: string;
+}
+```
+

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -183,6 +183,7 @@ const sidebars: SidebarsConfig = {
           collapsed: true,
           items: [
             'libraries/standards-sdk/overview',
+            'libraries/standards-sdk/hcs-2',
             {
               type: 'category',
               label: 'HCS-10',
@@ -197,12 +198,14 @@ const sidebars: SidebarsConfig = {
                 'libraries/standards-sdk/hcs-10/browser',
                 'libraries/standards-sdk/hcs-10/connections-manager',
                 'libraries/standards-sdk/hcs-10/examples',
-                'libraries/standards-sdk/hcs-10/server'
+                'libraries/standards-sdk/hcs-10/server',
+                'libraries/standards-sdk/hcs-10/showcase'
               ],
             },
             'libraries/standards-sdk/hcs-3',
             'libraries/standards-sdk/hcs-7',
             'libraries/standards-sdk/hcs-11',
+            'libraries/standards-sdk/hcs-20',
             'libraries/standards-sdk/inscribe',
             'libraries/standards-sdk/utils-services'
           ],

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -199,7 +199,7 @@ const sidebars: SidebarsConfig = {
                 'libraries/standards-sdk/hcs-10/connections-manager',
                 'libraries/standards-sdk/hcs-10/examples',
                 'libraries/standards-sdk/hcs-10/server',
-                'libraries/standards-sdk/hcs-10/showcase'
+                'libraries/standards-sdk/hcs-10/index'
               ],
             },
             'libraries/standards-sdk/hcs-3',

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -183,7 +183,6 @@ const sidebars: SidebarsConfig = {
           collapsed: true,
           items: [
             'libraries/standards-sdk/overview',
-            'libraries/standards-sdk/hcs-2',
             {
               type: 'category',
               label: 'HCS-10',

--- a/src/components/StandardsSDKShowcase.tsx
+++ b/src/components/StandardsSDKShowcase.tsx
@@ -9,10 +9,10 @@ const standardsSDKData = [
     icon: '📖',
   },
   {
-    title: 'HCS-10 SDK',
-    href: '/docs/libraries/standards-sdk/hcs-10/',
-    description: 'OpenConvAI Standard SDK for building AI agent communication systems',
-    icon: '🤖',
+    title: 'HCS-2 SDK',
+    href: '/docs/libraries/standards-sdk/hcs-2',
+    description: 'Decentralized Topic Registry for managing HCS topics',
+    icon: '📋',
   },
   {
     title: 'HCS-3 Integration',
@@ -27,10 +27,22 @@ const standardsSDKData = [
     icon: '💎',
   },
   {
+    title: 'HCS-10 SDK',
+    href: '/docs/libraries/standards-sdk/hcs-10/',
+    description: 'OpenConvAI Standard SDK for building AI agent communication systems',
+    icon: '🤖',
+  },
+  {
     title: 'HCS-11 Integration',
     href: '/docs/libraries/standards-sdk/hcs-11',
     description: 'SDK implementation for HCS-11 Profile Metadata standard',
     icon: '👤',
+  },
+  {
+    title: 'HCS-20 SDK',
+    href: '/docs/libraries/standards-sdk/hcs-20',
+    description: 'Auditable Points Standard for creating and managing loyalty points',
+    icon: '🪙',
   },
   {
     title: 'Inscribe Utilities',


### PR DESCRIPTION
# Add HCS-2 and HCS-20 Documentation

This PR introduces documentation for  HCS-2 and HCS-20 standards and updates the site navigation accordingly.

## Changes

- **Added HCS-2 documentation** 
- **Added HCS-20 documentation** 
- **Updated sidebar configuration** - Added navigation links for both new standards
- **Updated StandardsSDKShowcase component** - Reflects the new SDK additions

## What's New

- HCS-2: Decentralized Topic Registry
- HCS-20: Auditable Points Standard

Both standards are now fully documented and accessible through the site navigation.