### PR TITLE
[improvement] Non-indexed registries only need the latest message processed

### DIFF
--- a/docs/standards/hcs-2.md
+++ b/docs/standards/hcs-2.md
@@ -249,7 +249,6 @@ Examples:
 
 - Expectation for new records to be continually added.
 - Indexers should gather `only the last message` and metadata in that message will determine the protocol and execution.
-- Processing state should start from the first message and proceed to the last sequential message number.
 
 ## TTL Use Cases
 


### PR DESCRIPTION
A small update to the docs to remove a confusing bullet point on Non indexed registries that was left over from copying the docs for the indexed registry.